### PR TITLE
Any -> record

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prepublishOnly": "yarn build",
     "build": "tsc",
-    "test": "ava --timeout=1m",
+    "test": "ava",
     "test:lint": "eslint --ext ts src test",
     "test:coverage": "npx nyc check-coverage --lines 90 --functions 90 --branches 90",
     "coverage": "npx nyc --require ts-node/register --require source-map-support/register npm test",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prepublishOnly": "yarn build",
     "build": "tsc",
-    "test": "ava",
+    "test": "ava --timeout=1m",
     "test:lint": "eslint --ext ts src test",
     "test:coverage": "npx nyc check-coverage --lines 90 --functions 90 --branches 90",
     "coverage": "npx nyc --require ts-node/register --require source-map-support/register npm test",

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,14 +101,19 @@ export class Type {
 	 * Get the deep type name that defines the input.
 	 */
 	private check(): void {
+		/* eslint-disable curly */
 		if (Object.isFrozen(this)) return;
 		const promise = getPromiseDetails(this.value);
 		if (typeof this.value === 'object' && this.isCircular()) this.is = `[Circular:${this.is}]`;
 		else if (promise && promise[0]) this.addValue(promise[1]);
 		else if (this.value instanceof Map) for (const entry of this.value) this.addEntry(entry);
 		else if (Array.isArray(this.value) || this.value instanceof Set) for (const value of this.value) this.addValue(value);
-		else if (this.is === 'Object') this.is = 'any';
+		else if (this.is === 'Object') {
+			this.is = 'Record';
+			for (const entry of Object.entries(this.value as Record<PropertyKey, unknown>)) this.addEntry(entry);
+		}
 		Object.freeze(this);
+		/* eslint-enable curly */
 	}
 
 	/**
@@ -130,7 +135,7 @@ export class Type {
 	 * @param values The values to list
 	 */
 	private static list(values: Map<string, Type>): string {
-		return values.has('Object') ? 'any' : [...values.values()].sort().join(' | ');
+		return [...values.values()].sort().join(' | ');
 	}
 
 }

--- a/test/maps.ts
+++ b/test/maps.ts
@@ -14,5 +14,5 @@ ava('map(different-type)', (test): void => {
 });
 
 ava('map(mixed with object)', (test): void => {
-	test.is(new Type(new Map<string, any>([['text', 'abc'], ['digit', 1], ['object', {}]])).toString(), 'Map<string, any>');
+	test.is(new Type(new Map<string, any>([['text', 'abc'], ['digit', 1], ['object', {}]])).toString(), 'Map<string, Record | number | string>');
 });

--- a/test/objects.ts
+++ b/test/objects.ts
@@ -2,7 +2,7 @@ import ava from 'ava';
 import { Type } from '../dist';
 
 ava('object(generic)', (test): void => {
-	test.is(new Type({}).toString(), 'any');
+	test.is(new Type({}).toString(), 'Record');
 });
 
 ava('object(null)', (test): void => {
@@ -10,6 +10,14 @@ ava('object(null)', (test): void => {
 });
 
 ava('object(custom)', (test): void => {
-	class Foo {}
+	class Foo { }
 	test.is(new Type(new Foo()).toString(), 'Foo');
+});
+
+ava('object(types)', (test): void => {
+	test.is(new Type({ foo: 'bar', baz: 2, hello: true }).toString(), 'Record<string, boolean | number | string>');
+});
+
+ava('object(recursive)', (test): void => {
+	test.is(new Type({ foo: 'bar', hello: { baz: 'world' } }).toString(), 'Record<string, Record<string, string> | string>');
 });


### PR DESCRIPTION
This changes Objects becoming `any` to Objects becoming the TS type `Record` with it's keys and values becoming typed as well

```js
console.log(new Type({ foo: 'bar' }).toString()) // Logs 'any'
```
vs
```js
console.log(new Type({ foo: 'bar' }).toString()) // Logs 'Record<string, string>'
```